### PR TITLE
[Add] 일반맵에서 캐릭터 맵으로 넘어갈 때 스텟을 저장해서 불러오는 기능 추가

### DIFF
--- a/Content/Blueprints/Characters/Player/BP_ShooterPlayerController.uasset
+++ b/Content/Blueprints/Characters/Player/BP_ShooterPlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ed48d341d85dd69a3148de82352bc1b75b27295fe7d2efdc4bd7de4b595d74c5
-size 309630
+oid sha256:36ad881736fbc997dd1eb494e0292598132078c047b5483c77c3b51f3593c1bc
+size 319517

--- a/Source/TheFourthDescendant/GameManager/MainGameInstance.cpp
+++ b/Source/TheFourthDescendant/GameManager/MainGameInstance.cpp
@@ -13,6 +13,8 @@ UMainGameInstance::UMainGameInstance()
 	HitProjectileCount = 0;
 	DeathCount = 0;
 	EvasionAttackCount = 0;
+	bHasPlayerSaved = false;
+	CharacterSaveData = FCharacterSaveData();
 }
 
 void UMainGameInstance::Init()
@@ -33,6 +35,8 @@ void UMainGameInstance::ResetValue()
 	HitProjectileCount = 0;
 	DeathCount = 0;
 	EvasionAttackCount = 0;
+	bHasPlayerSaved = false;
+	CharacterSaveData = FCharacterSaveData();
 }
 
 // 구현
@@ -84,6 +88,12 @@ void UMainGameInstance::SubtractEvasionAttackCount(const int32 Amount)
 {
 	EvasionAttackCount -= Amount;
 	//GEngine->AddOnScreenDebugMessage(-1, 2.f, FColor::Black, FString::Printf(TEXT("EvasionAttackCount : %d"),EvasionAttackCount));
+}
+
+void UMainGameInstance::SaveCharacterData(FCharacterSaveData NewCharacterData)
+{
+	bHasPlayerSaved = true;
+	CharacterSaveData = NewCharacterData;
 }
 
 void UMainGameInstance::AddPlayTimeOneSecond()

--- a/Source/TheFourthDescendant/GameManager/MainGameInstance.h
+++ b/Source/TheFourthDescendant/GameManager/MainGameInstance.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Engine/GameInstance.h"
+#include "TheFourthDescendant/Player/PlayerCharacter.h"
 #include "MainGameInstance.generated.h"
 
 UCLASS()
@@ -42,6 +43,8 @@ public:
 	/** 플레이 타임 체크용 타이머 핸들 */
 	FTimerHandle PlayTimeTimer;
 
+	bool bHasPlayerSaved;
+	FCharacterSaveData CharacterSaveData;
 public:
 	virtual void Init();
 	/** 전역 변수 초기화 함수 */
@@ -64,6 +67,7 @@ public:
 	/** 회피한 횟수 감소 */
 	void SubtractEvasionAttackCount(const int32 Amount);
 
+	void SaveCharacterData(FCharacterSaveData NewCharacterData);
 private:
 	/** 1초마다 플레이 타임 1초 증가 */
 	void AddPlayTimeOneSecond();

--- a/Source/TheFourthDescendant/Player/PlayerCharacter.cpp
+++ b/Source/TheFourthDescendant/Player/PlayerCharacter.cpp
@@ -99,6 +99,49 @@ APlayerCharacter::APlayerCharacter()
 	Tags.Add(TEXT("Player"));
 }
 
+FCharacterSaveData APlayerCharacter::SerializeCharacterData()
+{
+	FCharacterSaveData Data;
+
+	Data.Health = Status.Health;
+	for (const EAmmoType AmmoType : TEnumRange<EAmmoType>())
+	{
+		Data.AmmoInventory.Add(AmmoInventory[AmmoType]);
+	}
+	for (AWeaponBase* Weapon : WeaponSlots)
+	{
+		if (Weapon)
+		{
+			Data.WeaponAmmoInventory.Add(Weapon->GetCurrentAmmo());
+		}
+	}
+
+	return Data;
+}
+
+// Pre Condition : InitInventory, InitWeaponSlot이 호출되어서 이미 초기화가 진행된 상태이어야 한다.
+void APlayerCharacter::DeserializeCharacterData(const FCharacterSaveData& Data)
+{
+	Status.Health = Data.Health;
+	OnHealthAndShieldChanged.Broadcast(FDurableChangeInfo(Status));
+
+	// AddAmmo와 동일 로직, 추후 개선 고려
+	for (const EAmmoType AmmoType : TEnumRange<EAmmoType>())
+	{
+		AmmoInventory[AmmoType] = Data.AmmoInventory[static_cast<int32>(AmmoType)];
+		OnTotalAmmoChanged.Broadcast(AmmoType, AmmoInventory[AmmoType]);
+	}
+
+	// Equip으로 이미 Binding된 것을 가정한다.
+	for (int i = 0; i < Data.WeaponAmmoInventory.Num(); ++i)
+	{
+		if (WeaponSlots.IsValidIndex(i) && WeaponSlots[i])
+		{
+			WeaponSlots[i]->SetCurrentAmmo(Data.WeaponAmmoInventory[i]);
+		}
+	}
+}
+
 void APlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
 	Super::SetupPlayerInputComponent(PlayerInputComponent);
@@ -689,6 +732,8 @@ void APlayerCharacter::BeginPlay()
 {
 	Super::BeginPlay();
 
+	UE_LOG(LogTemp, Warning, TEXT("PlayerCharacter BeginPlay"));
+	
 	GetCharacterMovement()->MaxWalkSpeed = Status.WalkSpeed;
 	SpringArmComponent->TargetArmLength = NormalSpringArmLength;
 

--- a/Source/TheFourthDescendant/Player/PlayerCharacter.cpp
+++ b/Source/TheFourthDescendant/Player/PlayerCharacter.cpp
@@ -14,6 +14,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetMathLibrary.h"
 #include "TheFourthDescendant/GameManager/MainGameInstance.h"
+#include "TheFourthDescendant/GameManager/MainGameStateBase.h"
 #include "TheFourthDescendant/Weapon/WeaponBase.h"
 
 const FName APlayerCharacter::LWeaponSocketName(TEXT("LHandWeaponSocket"));
@@ -746,6 +747,25 @@ void APlayerCharacter::BeginPlay()
 
 	PrevShield = Status.Shield;
 	OnHealthAndShieldChanged.Broadcast(FDurableChangeInfo(Status));
+	
+	if (UMainGameInstance* MainGameInstance = GetGameInstance<UMainGameInstance>())
+	{
+		if (MainGameInstance->bHasPlayerSaved)
+		{
+			DeserializeCharacterData(MainGameInstance->CharacterSaveData);
+		}
+	}
+
+	if (AMainGameStateBase* MainGameState = GetWorld()->GetGameState<AMainGameStateBase>())
+	{
+		MainGameState->LevelEnded.AddLambda([this]()
+		{
+			if (UMainGameInstance* MainGameInstance = GetGameInstance<UMainGameInstance>())
+			{
+				MainGameInstance->SaveCharacterData(SerializeCharacterData());
+			}
+		});
+	}
 }
 
 void APlayerCharacter::OnDamageSoundCoolDown()

--- a/Source/TheFourthDescendant/Player/PlayerCharacter.h
+++ b/Source/TheFourthDescendant/Player/PlayerCharacter.h
@@ -62,6 +62,16 @@ struct FDurableChangeInfo
 	float Shield;
 };
 
+USTRUCT(BlueprintType)
+struct FCharacterSaveData
+{
+	GENERATED_BODY()
+
+	int32 Health;
+	TArray<int32> AmmoInventory;
+	TArray<int32> WeaponAmmoInventory;
+};
+
 /**
  * 플레이어 캐릭터 클래스
  * 캐릭터는 다음과 같은 상태를 가진다.
@@ -121,10 +131,13 @@ public:
 	/** 장전 애니메이션 재생 여부, ABP에서 값을 전달 받는다.*/
 	UPROPERTY(BlueprintReadWrite, Category = "Player|Animation")
 	bool bIsOnAttackAnimState;
+
+	FCharacterSaveData SerializeCharacterData();
+	void DeserializeCharacterData(const FCharacterSaveData& Data);
 protected:
 	// FStateMachineContext StateMachineContext;
 	FTimerHandle DeathMontageTimerHandle;
-
+	
 	/** 무적 상태 여부 */
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "Player|Status")
 	bool bInvincible;

--- a/Source/TheFourthDescendant/Weapon/WeaponBase.cpp
+++ b/Source/TheFourthDescendant/Weapon/WeaponBase.cpp
@@ -39,6 +39,12 @@ AWeaponBase::AWeaponBase()
 	MuzzleFlashAttachRotator = FRotator::ZeroRotator;
 }
 
+void AWeaponBase::SetCurrentAmmo(int NewAmmo)
+{
+	CurrentAmmo = NewAmmo;
+	OnAmmoChanged.Broadcast(CurrentAmmo);
+}
+
 void AWeaponBase::Tick(float DeltaSeconds)
 {
 	Super::Tick(DeltaSeconds);

--- a/Source/TheFourthDescendant/Weapon/WeaponBase.h
+++ b/Source/TheFourthDescendant/Weapon/WeaponBase.h
@@ -58,6 +58,7 @@ public:
 	/** 사격 발생 시에 발생할 이벤트 */
 	UPROPERTY(BlueprintAssignable, Category = "Weapon|Events")
 	FOnShootTriggered OnShootTriggered;
+	void SetCurrentAmmo(int NewAmmo);
 protected:
 	/** ApplyRecoil을 호출해서 반동 감쇄*/
 	virtual void Tick(float DeltaSeconds) override;


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 캐릭터 정보 저장 기능 추가
- GameInstance에 캐릭터 데이터 저장 기능 추가
- Load 시에 GameInstance의 정보 불러오기 기능 추가
<!---- Issue를 해결한 경우엔 Resolves: #(Isuue Number) -->

<!---- 자신이 올리고 최소 1명 이상의 코드 리뷰를 받으세요. 본인이 머지를 하면 안됍니다. -->

## PR 유형
어떤 변경 사항이 있나요? <!---- 체크는 풀리퀘스트 생성 후 게시글에서 체크 가능합니다 -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://github.com/NbcampUnreal/1st-Team4-CH3-Project/wiki) 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
